### PR TITLE
fix: permission denied when running on Jenkins

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -83,7 +83,12 @@ jobs:
         TAG=$GITHUB_SHA
         docker build . \
             --file Dockerfile \
-            --tag $IMAGE_NAME:$TAG
+            --tag $IMAGE_NAME:$TAG \
+            # TODO: find alternative instead of building image in Jenkins
+            # This will only add new user in the Github
+            # Unable to map with host user in our Jenkins (unless runs on the Jenkins)
+            --build-arg USER_ID=$(id -u) \
+            --build-arg GROUP_ID=$(id -g)
 
     - name: Inspect local docker image
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,20 +155,19 @@ RUN echo "kotlin & gradle" && \
 RUN mkdir -p $ANDROID_HOME/licenses
 COPY sdk/licenses/* $ANDROID_HOME/licenses/
 
+ENV JENKINS_DEFAULT_ID=1000
+
+# Create new (Jenkins Users)
+RUN addgroup --gid $JENKINS_DEFAULT_ID jenkins
+RUN adduser --disabled-password --gecos '' --uid $JENKINS_DEFAULT_ID --gid $JENKINS_DEFAULT_ID jenkins
+USER jenkins
+
 # Create some jenkins required directory to allow this image run with Jenkins
 RUN mkdir -p /var/lib/jenkins/workspace && \
     mkdir -p /home/jenkins && \
     chmod 777 /home/jenkins && \
     chmod 777 /var/lib/jenkins/workspace && \
     chmod -R 775 $ANDROID_HOME
-    
-# Create new (Jenkins Users)
-ARG USER_ID
-ARG GROUP_ID
-
-RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID jenkins
-RUN addgroup --gid $GROUP_ID jenkins
-USER jenkins
 
 COPY Gemfile /Gemfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,6 +161,14 @@ RUN mkdir -p /var/lib/jenkins/workspace && \
     chmod 777 /home/jenkins && \
     chmod 777 /var/lib/jenkins/workspace && \
     chmod -R 775 $ANDROID_HOME
+    
+# Create new (Jenkins Users)
+ARG USER_ID
+ARG GROUP_ID
+
+RUN addgroup --gid $GROUP_ID jenkins
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID jenkins
+USER jenkins
 
 COPY Gemfile /Gemfile
 
@@ -183,16 +191,6 @@ RUN git clone https://github.com/jenv/jenv.git ~/.jenv && \
     jenv versions && \
     jenv global 11 && \
     java -version
-    
-# Create new jenkins user
-USER root
-RUN adduser --gecos "" --disabled-password --quiet jenkins
-RUN echo "jenkins:jenkins" | chpasswd
-
-# Add `jenkins` user
-RUN chown -R jenkins:jenkins ${ANDROID_HOME}
-RUN chown -R jenkins:jenkins ${ANDROID_SDK_HOME}
-USER jenkins
 
 COPY README.md /README.md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,8 +166,8 @@ RUN mkdir -p /var/lib/jenkins/workspace && \
 ARG USER_ID
 ARG GROUP_ID
 
-RUN addgroup --gid $GROUP_ID jenkins
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID jenkins
+RUN addgroup --gid $GROUP_ID jenkins
 USER jenkins
 
 COPY Gemfile /Gemfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,6 +183,16 @@ RUN git clone https://github.com/jenv/jenv.git ~/.jenv && \
     jenv versions && \
     jenv global 11 && \
     java -version
+    
+# Create new jenkins user
+USER root
+RUN adduser --gecos "" --disabled-password --quiet jenkins
+RUN echo "jenkins:jenkins" | chpasswd
+
+# Add `jenkins` user
+RUN chown -R jenkins:jenkins ${ANDROID_HOME}
+RUN chown -R jenkins:jenkins ${ANDROID_SDK_HOME}
+USER jenkins
 
 COPY README.md /README.md
 


### PR DESCRIPTION
This PR when merged will have a same tags, e.g: `2.0.0-jenkins` and make sure this is not shipped in `latest` tag (as it might break our Gitlab CI permission related) 

ref:

1. https://stackoverflow.com/questions/52683091/how-to-build-a-docker-image-for-jenkins-with-android-and-docker-build-support
1. https://stackoverflow.com/a/58027325/3763032
1. [sudo adduser](https://stackoverflow.com/a/48450294/3763032)